### PR TITLE
Sidenote commas

### DIFF
--- a/site-style.css.pp
+++ b/site-style.css.pp
@@ -175,6 +175,13 @@ top: -0.5rem;
 left: 0.1rem;
 }
 
+.sidenote-comma {
+position: relative;
+font-size: 0.7rem;
+top: -0.5rem;
+left: 0.1rem;
+}
+
 .sidenote:before { content: counter(sidenote-counter) ". "; top: 0rem; }
 
 input.margin-toggle { display: none; }


### PR DESCRIPTION
Automatically detects successive side-/footnotes and inserts commas between the numbers in the text. Works with directly-adjacent notes as well as notes separated by whitespace.